### PR TITLE
Node management improvements and fixes 2

### DIFF
--- a/node_management/manage_supra_nodes.sh
+++ b/node_management/manage_supra_nodes.sh
@@ -575,7 +575,7 @@ EOF
     local bucket_name="mainnet"
     # Define the custom endpoint for Cloudflare R2
     local endpoint_url="https://4ecc77f16aaa2e53317a19267e3034a4.r2.cloudflarestorage.com"
-    local aws_options="--endpoint-url '$endpoint_url' --delete"
+    local aws_options="--endpoint-url $endpoint_url --delete"
 
     if [ -n "$EXACT_TIMESTAMPS" ]; then
         aws_options+=" --exact-timestamps"

--- a/node_management/manage_supra_nodes.sh
+++ b/node_management/manage_supra_nodes.sh
@@ -54,7 +54,6 @@ function parse_sync_optional_args() {
 function parse_args() {
     FUNCTION="$1"
     NODE_TYPE="$2"
-    OTHER_ARGS=("${@:2}")
 
     case "$FUNCTION" in
     setup | update)
@@ -68,9 +67,11 @@ function parse_args() {
         HOST_SUPRA_HOME="$4"
         ;;
     sync)
-        local remaining_args=($(parse_sync_optional_args "${OTHER_ARGS[@]}"))
-        HOST_SUPRA_HOME="${remaining_args[0]}"
-        NETWORK="${remaining_args[1]}"
+        local remaining_args=($(parse_sync_optional_args "${@:2}"))
+        NODE_TYPE="${remaining_args[0]}"
+        HOST_SUPRA_HOME="${remaining_args[2]}"
+        NETWORK="${remaining_args[2]}"
+        echo "$FUNCTION $NODE_TYPE $SNAPSHOT_SOURCE $HOST_SUPRA_HOME $NETWORK"
         ;;
     esac
 
@@ -257,7 +258,7 @@ function start_rpc_docker_container() {
 # Creates a timestamped backup if the file exists and gets replaced.
 # Usage:
 #   backup_and_download_if_outdated <file_path> <download_url> <new_version> [<label>]
-backup_and_download_if_outdated() {
+function backup_and_download_if_outdated() {
     local file_path="$1"
     local download_url="$2"
     local new_version_full="$3"

--- a/node_management/manage_supra_nodes.sh
+++ b/node_management/manage_supra_nodes.sh
@@ -150,7 +150,7 @@ function start_usage() {
 }
 
 function sync_usage() {
-    echo "Usage: ./$SCRIPT_NAME.sh sync <node_type> <host_supra_home> <network> [exact_timestamps]" >&2
+    echo "Usage: ./$SCRIPT_NAME.sh sync <node_type> <host_supra_home> <network>" >&2
     echo "Parameters:" >&2
     node_type_usage
     host_supra_home_usage

--- a/node_management/manage_supra_nodes.sh
+++ b/node_management/manage_supra_nodes.sh
@@ -36,18 +36,25 @@ function parse_sync_optional_args() {
             # don't accidentally sync the snapshot for the wrong environment.
             SNAPSHOT_SOURCE="$2"
             # Shift out the args parameter.
-            shift
+            shift || break
             ;;
-        *) break ;;
+        *)
+            break
+        ;;
         esac
+
         # Move to the next arg.
-        shift
+        shift || break
     done
+
+    # Return the remaining args.
+    echo "$@"
 }
 
 function parse_args() {
     FUNCTION="$1"
     NODE_TYPE="$2"
+    OTHER_ARGS=("${@:2}")
 
     case "$FUNCTION" in
     setup | update)
@@ -61,12 +68,9 @@ function parse_args() {
         HOST_SUPRA_HOME="$4"
         ;;
     sync)
-        # Shift out the already-processed args.
-        shift 2
-        parse_sync_optional_args "$@"
-        # The above function shifts out all optional args, so we're back to $1.
-        HOST_SUPRA_HOME="$1"
-        NETWORK="$2"
+        local remaining_args=($(parse_sync_optional_args "${OTHER_ARGS[@]}"))
+        HOST_SUPRA_HOME="${remaining_args[0]}"
+        NETWORK="${remaining_args[1]}"
         ;;
     esac
 
@@ -138,6 +142,7 @@ function update_usage() {
 
 function start_usage() {
     echo "Usage: ./$SCRIPT_NAME.sh start <node_type> <container_name> <host_supra_home>" >&2
+    echo "Parameters:" >&2
     node_type_usage
     container_name_usage
     host_supra_home_usage
@@ -146,6 +151,7 @@ function start_usage() {
 
 function sync_usage() {
     echo "Usage: ./$SCRIPT_NAME.sh sync <node_type> <host_supra_home> <network> [exact_timestamps]" >&2
+    echo "Parameters:" >&2
     node_type_usage
     host_supra_home_usage
     network_usage

--- a/node_management/manage_supra_nodes.sh
+++ b/node_management/manage_supra_nodes.sh
@@ -25,32 +25,6 @@ function is_update() {
     [[ "$FUNCTION" = "update" ]]
 }
 
-function parse_sync_optional_args() {
-    while :; do
-        case $1 in
-        -e | --exact-timestamps)
-            EXACT_TIMESTAMPS="SET"
-            ;;
-        -s | --snapshot-source)
-            # TODO: Could add verification for this parameter to ensure that operators
-            # don't accidentally sync the snapshot for the wrong environment.
-            SNAPSHOT_SOURCE="$2"
-            # Shift out the args parameter.
-            shift || break
-            ;;
-        *)
-            break
-        ;;
-        esac
-
-        # Move to the next arg.
-        shift || break
-    done
-
-    # Return the remaining args.
-    echo "$@"
-}
-
 function parse_args() {
     FUNCTION="$1"
     NODE_TYPE="$2"
@@ -67,11 +41,35 @@ function parse_args() {
         HOST_SUPRA_HOME="$4"
         ;;
     sync)
-        local remaining_args=($(parse_sync_optional_args "${@:2}"))
-        NODE_TYPE="${remaining_args[0]}"
-        HOST_SUPRA_HOME="${remaining_args[2]}"
-        NETWORK="${remaining_args[2]}"
-        echo "$FUNCTION $NODE_TYPE $SNAPSHOT_SOURCE $HOST_SUPRA_HOME $NETWORK"
+        # Shift out `<function>`.
+        shift
+
+        # Parse the optional args.
+        while :; do
+            case $1 in
+            -e | --exact-timestamps)
+                EXACT_TIMESTAMPS="SET"
+                ;;
+            -s | --snapshot-source)
+                # TODO: Could add verification for this parameter to ensure that operators
+                # don't accidentally sync the snapshot for the wrong environment.
+                SNAPSHOT_SOURCE="$2"
+                # Shift out the args parameter.
+                shift || break
+                ;;
+            *)
+                break
+                ;;
+            esac
+
+            # Move to the next arg.
+            shift || break
+        done
+
+        # Parse the remaining expected args.
+        NODE_TYPE="$1"
+        HOST_SUPRA_HOME="$2"
+        NETWORK="$3"
         ;;
     esac
 

--- a/node_management/upload_snapshot.sh
+++ b/node_management/upload_snapshot.sh
@@ -14,7 +14,7 @@ function log() {
 
 function check_active_uploader() {
     CURRENT_UPLOADER_IP="$(rclone cat "$RCLONE_REMOTE/$UPLOADER_IP_FILE")"
-    LOCAL_IP="$(curl https://ipinfo.io/ip)"
+    LOCAL_IP="$(curl https://ipinfo.io/ip 2>/dev/null)"
 
     if [ -n "$CURRENT_UPLOADER_IP" ] && [[ "$LOCAL_IP" != "$CURRENT_UPLOADER_IP" ]]; then
         echo "Error: $CURRENT_UPLOADER_IP is already registered as the uploader for $RCLONE_REMOTE." >&2

--- a/node_management/upload_snapshot.sh
+++ b/node_management/upload_snapshot.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Directory to watch
+WATCH_DIR="$HOME/snapshot"
+RCLONE_REMOTE="cloudflare-r2:testnet-archive-snapshot/snapshots"
+SNAPSHOT_INFO_FILE="$WATCH_DIR/latest_snapshot_info"
+LOG_FILE="$HOME/sync_snapshots.log"
+LOCK_FILE=UPLOAD_IN_PROGRESS
+UPLOADER_IP_FILE=UPLOADER_IP
+
+function log() {
+    echo "$(date +'%Y-%m-%d %H:%M:%S') - $1" | tee -a "$LOG_FILE"
+}
+
+function check_active_uploader() {
+    CURRENT_UPLOADER_IP="$(rclone cat "$RCLONE_REMOTE/$UPLOADER_IP_FILE")"
+    LOCAL_IP="$(curl https://ipinfo.io/ip)"
+
+    if [ -n "$CURRENT_UPLOADER_IP" ] && [[ "$LOCAL_IP" != "$CURRENT_UPLOADER_IP" ]]; then
+        echo "Error: $CURRENT_UPLOADER_IP is already registered as the uploader for $RCLONE_REMOTE." >&2
+        echo "       If you intend to change the uploader, then please manually remove $RCLONE_REMOTE/$UPLOADER_IP_FILE" >&2
+        echo "       before continuing." >&2
+        exit 1
+    fi
+}
+
+function register_active_uploader() {
+    curl https://ipinfo.io/ip 2>/dev/null >"$UPLOADER_IP_FILE"
+    rclone copy "$UPLOADER_IP_FILE" "$RCLONE_REMOTE"
+}
+
+function sync_snapshot() {
+    local snapshot_info_file="$1"
+
+    log "Starting new sync for snapshot info: $snapshot_info_file"
+    # Read the JSON file to extract the paths
+    store_path=$(jq -r '.store' "$snapshot_info_file")
+    archive_path=$(jq -r '.archive' "$snapshot_info_file")
+
+    if [[ -d "$store_path" && -d "$archive_path" ]]; then
+        # Upload the marker to indicate that an upload is in progress.
+        date >"$LOCK_FILE"
+        rclone copy "$LOCK_FILE" "$RCLONE_REMOTE"
+
+        # Sync the store directory with time tracking
+        log "Syncing store directory: $store_path"
+        time rclone sync --checkers=32 "$store_path" "$RCLONE_REMOTE/store" 2>&1 | tee -a "$LOG_FILE"
+
+        # Sync the archive directory with time tracking
+        log "Syncing archive directory: $archive_path"
+        time rclone sync --checkers=32 "$archive_path" "$RCLONE_REMOTE/archive" 2>&1 | tee -a "$LOG_FILE"
+
+        # Remove the marker.
+        rclone delete "$RCLONE_REMOTE/$LOCK_FILE"
+        log "Sync completed."
+    else
+        log "Error: Store or archive paths are invalid."
+    fi
+}
+
+function main() {
+    # Check if there is already an uploader active to help to avoid accidental overwrites.
+    check_active_uploader
+    # Register this node as the active uploader.
+    register_active_uploader
+
+    # Monitor the file for modification events
+    inotifywait -m -e modify "$SNAPSHOT_INFO_FILE" | while read; do
+        sync_snapshot "$SNAPSHOT_INFO_FILE"
+    done
+}
+
+main "$@"

--- a/node_management/utils.sh
+++ b/node_management/utils.sh
@@ -91,7 +91,7 @@ function install_aws_cli() {
             sudo apt-get update && sudo apt-get install -y unzip
         fi
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-        unzip awscliv2.zip
+        unzip awscliv2.zip >/dev/null
         sudo ./aws/install
         rm -rf aws awscliv2.zip
     fi

--- a/node_management/utils.sh
+++ b/node_management/utils.sh
@@ -81,7 +81,6 @@ function prompt_for_cli_password() {
 
 # Helper function to install AWS CLI v2 if not already installed
 function install_aws_cli() {
-    
     export AWS_MAX_CONCURRENT_REQUESTS=350  # Adjust based on system resources
     export AWS_MAX_QUEUE_SIZE=10000  # Increase queue size for large downloads
 


### PR DESCRIPTION
Added `upload_snapshot.sh` and made changes to it to protect against accidental overwrites and to enable the download script to tell when an upload is in progress.

Added `--exact-timestamps` and `--snapshot-source` optional arguments for the `sync` command. Also ensured that the `sync` command always retrieves the `CURRENT` index file for each database from the snapshot. Also made the `sync` command aware of when an upload is in progress and automatically re-sync when it completes.