### PR TITLE
migrating to rclone to fix the diff sync issue with aws cli

### DIFF
--- a/node_management/manage_supra_nodes.sh
+++ b/node_management/manage_supra_nodes.sh
@@ -468,8 +468,6 @@ function install_rclone_if_missing() {
             echo ""
             exit 1
         fi
-    else
-        echo "✅ rclone is already installed."
     fi
 }
 #---------------------------------------------------------- Setup Rclone Config ----------------------------------------------------------
@@ -511,8 +509,6 @@ region = auto
 chunk_size = 512M
 upload_cutoff = 512M
 EOF
-    else
-        echo "✅ Rclone remote $RCLONE_REMOTE_NAME already exists."
     fi
 }
 #---------------------------------------------------------- Sync Snapshot Directory ----------------------------------------------------------
@@ -734,7 +730,6 @@ function sync() {
 
         echo ""
         echo "✅ Upload completed. Proceeding to sync..."
-        echo "📥 Downloading snapshot from $remote_root ..."
         sync_once "$remote_root"
     fi
 }


### PR DESCRIPTION
Resolves https://github.com/Entropy-Foundation/supra-nodeops-data/issues/676

**Additionally** -The snapshot download time for the RPC testnet has decreased from approximately 2 hours to about 45 minutes to 1 hour, representing a noticeable improvement in speed.